### PR TITLE
Read the json buffer fully.

### DIFF
--- a/cloud-examples/src/main/java/com/hortonworks/spark/cloud/persist/JsonSerialization.java
+++ b/cloud-examples/src/main/java/com/hortonworks/spark/cloud/persist/JsonSerialization.java
@@ -214,10 +214,7 @@ public class JsonSerialization<T> {
     }
     byte[] b = new byte[(int) len];
     FSDataInputStream dataInputStream = fs.open(path);
-    int count = dataInputStream.read(b);
-    if (verifyLength && count != len) {
-      throw new EOFException(path.toString() + ": read finished prematurely");
-    }
+    dataInputStream.readFully(0, b);
     return fromBytes(path.toString(), b);
   }
 


### PR DESCRIPTION
InputStream.read is a low level unbuffered api call that does not need to return
everything that was requested. Instead, we need to use readFully.